### PR TITLE
Update main.py - Remove #unity keyword

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ if __name__ == '__main__':
     keywords = [
         '#gamedev',
         '#indiedev',
-        '#unity',
         '#madewithunity',
         '#UE4',
         '#gamedev español',


### PR DESCRIPTION
The `#unity` keyword proves to be very broad, and appears in many conversations outside of game development.